### PR TITLE
guard against the possibility of GDAL not being available

### DIFF
--- a/apps/OGR.cpp
+++ b/apps/OGR.cpp
@@ -13,6 +13,7 @@
 
 *****************************************************************************/
 
+#ifdef HEXER_HAVE_GDAL
 
 #include <iostream>
 
@@ -275,3 +276,5 @@ OGR::~OGR()
 
 
 } //namespace
+
+#endif // HEXER_HAVE_GDAL

--- a/apps/OGR.hpp
+++ b/apps/OGR.hpp
@@ -16,17 +16,15 @@
 #ifndef INCLUDED_PSHAPE_OGR_HPP
 #define INCLUDED_PSHAPE_OGR_HPP
 
+#ifdef HEXER_HAVE_GDAL
+
 #include <hexer/hexer.hpp>
 #include <hexer/hexer_defines.h>
 #include <hexer/Processor.hpp>
 #include <hexer/GridInfo.hpp>
 
-#ifdef HEXER_HAVE_GDAL
-
 #include "ogr_api.h"
 #include "gdal.h"
-
-#endif
 
 #include "Mathpair.hpp"
 #include "export.hpp"
@@ -121,12 +119,10 @@ private:
     std::string m_filename;
     size_t m_index;
 
-#ifdef HEXER_HAVE_GDAL
     OGRDataSourceH m_ds;
 	OGRLayerH m_layer;
 	OGRFeatureH m_current_feature;
 	OGRGeometryH m_current_geometry;
-#endif
 
 
 public:
@@ -155,11 +151,9 @@ private:
     std::string m_filename;
 
 
-#ifdef HEXER_HAVE_GDAL
     OGRDataSourceH m_ds;
 	OGRLayerH m_layer;
 
-#endif
     void createLayer();
     void collectPath(Path* path, OGRGeometryH polygon);
 	OGRGeometryH collectHexagon(HexInfo const& info, HexGrid const* grid);
@@ -169,5 +163,7 @@ private:
 } // writer
 
 } // namespace
+
+#endif // HEXER_HAVE_GDAL
 
 #endif // file guard

--- a/apps/curse.cpp
+++ b/apps/curse.cpp
@@ -17,8 +17,10 @@
 #include <hexer/hexer.hpp>
 #include <hexer/Utils.hpp>
 #include "las.hpp"
-#include "OGR.hpp"
 
+#ifdef HEXER_HAVE_GDAL
+#include "OGR.hpp"
+#endif
 
 #include <fstream>
 #include <sstream>
@@ -191,9 +193,11 @@ void boundary(	std::string const& input,
         l.open();
         process(infos, l.reader);
     } else {
+#ifdef HEXER_HAVE_GDAL
         reader::OGR o(input);
         o.open();
         process(infos, o.reader);
+#endif
     }
 	   
     if (output.empty() || boost::iequals(output, "STDOUT"))
@@ -207,8 +211,10 @@ void boundary(	std::string const& input,
 	}
     else
     {
+#ifdef HEXER_HAVE_GDAL
         writer::OGR o(output);
         o.writeBoundary(infos);
+#endif
     }
     delete gi;
 }
@@ -239,13 +245,18 @@ void density(	std::string const& input,
         l.open();
         process(infos, l.reader);
     } else {
+#ifdef HEXER_HAVE_GDAL
         reader::OGR o(input);
         o.open();
         process(infos, o.reader);
+#endif
     }
 
+#ifdef HEXER_HAVE_GDAL
     writer::OGR o(output);
     o.writeDensity(infos);
+#endif
+
 	delete gi;
 }
 


### PR DESCRIPTION
I suppose you could also exclude OGR.cpp and OGR.hpp at the CMakeLists level. Curses.cpp may be a bit frail now though...OGR was the "else" in a number of places.
