### PR TITLE
fix remaining issues in #6, with some other tweaks

### DIFF
--- a/apps/curse.cpp
+++ b/apps/curse.cpp
@@ -13,26 +13,26 @@
 
 *****************************************************************************/
 
-#include <hexer/Processor.hpp>
-#include <hexer/hexer.hpp>
-#include <hexer/Utils.hpp>
-#include "las.hpp"
-
-#ifdef HEXER_HAVE_GDAL
-#include "OGR.hpp"
-#endif
-
 #include <fstream>
+#include <iostream>
 #include <sstream>
+#include <string>
+#include <vector>
 
 #include <boost/algorithm/string/compare.hpp>
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 
+#ifdef HEXER_HAVE_GDAL
+#include "OGR.hpp"
+#endif
+
+#include <hexer/hexer.hpp>
+#include <hexer/Processor.hpp>
+#include <hexer/Utils.hpp>
+#include "las.hpp"
+
 namespace po = boost::program_options;
-
-using namespace std;
-
 
 bool readHex(int& x, int& y, void* ctx)
 {
@@ -90,9 +90,9 @@ void dumpPath(hexer::Path *p)
     Orientation o = p->orientation();
     std::string ostring = ((o == CLOCKWISE) ? "CLOCKWISE" : "ANTICLOCKWISE");
     indent(level);
-    cerr << indent(level) << "Path length = " << p->pathLength() << "!\n";
-    cerr << indent(level) << "Orientation = " << ostring << "!\n";
-    vector<Path *> paths = p->subPaths();
+    std::cerr << indent(level) << "Path length = " << p->pathLength() << "!\n";
+    std::cerr << indent(level) << "Orientation = " << ostring << "!\n";
+    std::vector<Path *> paths = p->subPaths();
     level++;
     for (int pi = 0; pi != paths.size(); ++pi)
     {
@@ -106,7 +106,7 @@ void hextest(std::string filename)
 {
     using namespace hexer;
 
-    vector<GridInfo *> infos;
+    std::vector<GridInfo *> infos;
     GridInfo *gi = new GridInfo;
 
     gi->m_hexsize = 10;
@@ -123,7 +123,7 @@ void hextest(std::string filename)
     for (HexIter iter = gi->begin(); iter != gi->end(); ++iter)
     {
         HexInfo hi = *iter;
-        cerr << "Density/X/Y = " << hi.m_density << "/" <<
+        std::cerr << "Density/X/Y = " << hi.m_density << "/" <<
             hi.m_center.m_x << "/" << hi.m_center.m_y << "!\n";
     }
 
@@ -134,7 +134,7 @@ void pathtest(std::string filename)
 {
     using namespace hexer;
 
-    vector<GridInfo *> infos;
+    std::vector<GridInfo *> infos;
     GridInfo *gi = new GridInfo;
 
     infos.push_back(gi);
@@ -175,7 +175,7 @@ void boundary(	std::string const& input,
 {
     using namespace hexer;
 
-    vector<GridInfo *> infos;
+    std::vector<GridInfo *> infos;
     GridInfo *gi = new GridInfo;
 	
 	if (!hexer::compare_distance(edge, 0.0))
@@ -227,7 +227,7 @@ void density(	std::string const& input,
 {
     using namespace hexer;
 
-    vector<GridInfo *> infos;
+    std::vector<GridInfo *> infos;
     GridInfo *gi = new GridInfo;
 	
 	if (!hexer::compare_distance(edge, 0.0))
@@ -264,7 +264,7 @@ void density(	std::string const& input,
 void OutputHelp( std::ostream & oss, po::options_description const& options)
 {
     oss << "--------------------------------------------------------------------" << std::endl;
-    oss << "    curse (" << GetFullVersion() << ")" << std::endl;
+    oss << "    curse (" << hexer::GetFullVersion() << ")" << std::endl;
     oss << "--------------------------------------------------------------------" << std::endl;
 
     oss << options << std::endl;
@@ -348,7 +348,7 @@ int main(int argc, char* argv[])
 
     if (vm.count("version")) 
     {
-        std::cout << GetFullVersion() << std::endl;
+        std::cout << hexer::GetFullVersion() << std::endl;
         return 0;
     }
 

--- a/include/hexer/Processor.hpp
+++ b/include/hexer/Processor.hpp
@@ -13,14 +13,17 @@
 
 *****************************************************************************/
 
-#pragma once
+#ifndef INCLUDED_PROCESSOR_HPP
+#define INCLUDED_PROCESSOR_HPP
 
-#include <boost/function.hpp>
+#include <string>
 #include <vector>
 
-#include "GridInfo.hpp"
-#include "Path.hpp"
-#include "export.hpp"
+#include <boost/function.hpp>
+
+#include <hexer/GridInfo.hpp>
+#include <hexer/Path.hpp>
+#include <hexer/export.hpp>
 
 namespace hexer
 {
@@ -31,4 +34,8 @@ namespace hexer
     HEXER_DLL void processHexes(const std::vector<GridInfo *>& infos, HexReader);
     
     HEXER_DLL double computeHexSize(const std::vector<Point>& samples, int density);
+
+    HEXER_DLL std::string GetFullVersion( void );
 } // namespace hexer
+
+#endif // INCLUDED_PROCESSOR_HPP

--- a/include/hexer/hexer.hpp
+++ b/include/hexer/hexer.hpp
@@ -16,8 +16,6 @@
 #ifndef INCLUDED_HEXER_HPP
 #define INCLUDED_HEXER_HPP
 
-#include <string>
-
 #define HEXER_VERSION_MAJOR    1
 #define HEXER_VERSION_MINOR    0
 #define HEXER_VERSION_REVISION 0
@@ -25,7 +23,5 @@
 #include <hexer/hexer_defines.h>
 #include <hexer/exception.hpp>
 #include <hexer/gitsha.h>
-
-std::string GetFullVersion( void );
 
 #endif

--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -14,19 +14,18 @@
 *****************************************************************************/
 
 #include <hexer/Processor.hpp>
-#include <hexer/GridInfo.hpp>
-#include <hexer/Mathpair.hpp>
 
 #include <math.h>
 #include <sstream>
+#include <string>
 #include <vector>
-
 
 #ifdef HEXER_HAVE_GDAL
 #include "gdal.h"
 #endif
 
-using namespace std;
+#include <hexer/GridInfo.hpp>
+#include <hexer/Mathpair.hpp>
 
 namespace hexer
 {
@@ -40,7 +39,7 @@ namespace hexer
 
     // Compute hex size based on distance between consecutive points and density.
     // The probably needs some work based on more data.
-    double computeHexSize(const vector<Point>& samples, int density)
+    double computeHexSize(const std::vector<Point>& samples, int density)
     {
         double dist = 0;
         for (std::vector<Point>::size_type i = 0; i < samples.size() - 1; ++i)
@@ -55,7 +54,7 @@ namespace hexer
 
 void process(const std::vector<GridInfo *>& infos, PointReader reader)
 {
-    vector<Point> samples;
+    std::vector<Point> samples;
 
     int cnt = 0;
     double x, y;
@@ -115,8 +114,6 @@ void processHexes(const std::vector<GridInfo *>& infos, HexReader reader)
     }
 }
 
-} //namespace hexer
-
 std::string GetFullVersion( void )
 {
     std::ostringstream os;
@@ -137,3 +134,5 @@ std::string GetFullVersion( void )
 
     return os.str();
 }
+
+} //namespace hexer


### PR DESCRIPTION
Moved GetFullVersion() into hexer namespace, moved declaration to
Processor.hpp (defintion is in Processor.cpp), and added HEXER_DLL.

Also removed 'using namespace std' to clean up the global namespace,
which required explicit includes for things such as string, vector, etc.
