### PR TITLE
Set HEXER_UTILITIES so curse gets installed

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -6,6 +6,8 @@ include_directories(
     ${GDAL_INCLUDE_DIR})
 
 set(CURSE curse)
+set(HEXER_UTILITIES
+  ${CURSE})
 
 if(WIN32)
 if(NOT BUILD_STATIC)


### PR DESCRIPTION
Before this patch, curse was not installed to the system with an
install.
