### PR TITLE
Always set C++11 flag via cmake.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ cmake_install.cmake
 bin/
 include/hexer/hexer_defines.h
 install_manifest.txt
+curse
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,9 +131,7 @@ if (GDAL_FOUND)
     set(HEXER_HAVE_GDAL 1)
 endif()
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 ###############################################################################
 # Installation settings

--- a/src/HexGrid.cpp
+++ b/src/HexGrid.cpp
@@ -13,6 +13,8 @@
 
 *****************************************************************************/
 
+#include <cmath>
+
 #include <hexer/HexGrid.hpp>
 #include <hexer/Mathpair.hpp>
 #include <hexer/Processor.hpp>

--- a/src/gitsha.cpp
+++ b/src/gitsha.cpp
@@ -1,3 +1,3 @@
 #include <hexer/gitsha.h>
-#define GIT_SHA1 "bf38b0e5f8b9b271068a8fc799d2700f21e5f3c0"
+#define GIT_SHA1 "11d3586805529c6b954a403af4a8346d9b1dc2ee"
 const char g_GIT_SHA1[] = GIT_SHA1;


### PR DESCRIPTION
See #13.  Set -std=c++11 for all compilers.  Add a #include to make Ubuntu happy.
