### PR TITLE
Cleanup embedded boost's cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,10 @@ if(Boost_FOUND)
         set(Boost_USE_MULTITHREADED ON)
       #  set(Boost_USE_STATIC_RUNTIME ON)
 		endif()	
+else()
+    set(HEXERBOOST_LIB_NAME hexerboost)
+    add_subdirectory(boost)
+    include_directories(${PROJECT_SOURCE_DIR}/boost)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,6 @@ if(Boost_FOUND)
         set(Boost_USE_MULTITHREADED ON)
       #  set(Boost_USE_STATIC_RUNTIME ON)
 		endif()	
-    message(STATUS "External boost not found, using embedded boost tree")
 endif()
 
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 if(CURSE)
     add_executable(${CURSE} curse.cpp lasfile.hpp las.hpp las.cpp OGR.hpp OGR.cpp)
-    target_link_libraries(${CURSE} ${HEXER_LIB_NAME}  )
+    target_link_libraries(${CURSE} ${HEXER_LIB_NAME} ${HEXERBOOST_LIB_NAME})
 endif()
 
 install(TARGETS ${HEXER_UTILITIES}


### PR DESCRIPTION
Hexer didn't build correctly against its embedded boost. This patch fixes it up so it does.

I don't necessarily love the logic paths (HEXER_EMBED_BOOST is mostly ignored), but I wanted to make this patch low-impact.