### PR TITLE
Eliminate (vs2015) build error by making comparison operator constant

### DIFF
--- a/include/hexer/Hexagon.hpp
+++ b/include/hexer/Hexagon.hpp
@@ -97,7 +97,7 @@ private:
 class HexCompare
 {
 public:
-    bool operator()(const Hexagon *h1, const Hexagon *h2)
+    bool operator()(const Hexagon *h1, const Hexagon *h2) const
         { return h1->less(h2); }
 };
 


### PR DESCRIPTION
Building with vs2015 I got the following error:

```
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\xtree(2009): error C3848: expression having type 'const hexer::HexCompare' would lose some const-volatile qualifiers in order to call 'bool hexer::HexCompare::operator ()(const hexer::Hexagon *,const hexer::Hexagon *)'
```

Making the Hexagon comparison operator constant eliminates that error.