### PR TITLE
Configure gitsha.cpp into build dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
 configure_file(
   "${PROJECT_SOURCE_DIR}/gitsha.cpp.in"
-  "${PROJECT_SOURCE_DIR}/src/gitsha.cpp")
+  "${PROJECT_BINARY_DIR}/src/gitsha.cpp")
 
 add_subdirectory(src)
 add_subdirectory(apps)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@ set(HEXER_CPP
     Path.cpp
     Processor.cpp
     Segment.cpp
-    gitsha.cpp
+    "${PROJECT_BINARY_DIR}/src/gitsha.cpp"
 )
 
 set(HEXER_SOURCES

--- a/src/gitsha.cpp
+++ b/src/gitsha.cpp
@@ -1,3 +1,0 @@
-#include <hexer/gitsha.h>
-#define GIT_SHA1 "b580f07d41a660a35e38d99936547e646d25740b"
-const char g_GIT_SHA1[] = GIT_SHA1;


### PR DESCRIPTION
This prevents the cmake configuration process from modifying the working
directory, which annoyingly makes git report the repo as dirty.