### PR TITLE
Alpine linux does not have execinfo/backtrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,8 @@ endif(WIN32)
 
 set(hexer_defines_h_in "${CMAKE_CURRENT_SOURCE_DIR}/hexer_defines.h.in")
 set(hexer_defines_h "${CMAKE_CURRENT_BINARY_DIR}/include/hexer/hexer_defines.h")
+include(CheckIncludeFiles)
+check_include_files(execinfo.h HEXER_HAVE_EXECINFO_H)
 configure_file(${hexer_defines_h_in} ${hexer_defines_h})
 HEXER_ADD_INCLUDES("" "" ${hexer_defines_h})
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)

--- a/apps/Utils.cpp
+++ b/apps/Utils.cpp
@@ -44,7 +44,9 @@
 #include <cxxabi.h>
 #include <sys/ioctl.h>
 #include <sys/wait.h>  // WIFEXITED, WEXITSTATUS
+#ifdef HEXER_HAVE_EXECINFO_H
 #include <execinfo.h> // backtrace
+#endif
 #include <dlfcn.h> // dladdr
 #endif
 
@@ -600,11 +602,11 @@ double Utils::normalizeLongitude(double longitude)
     return longitude;
 }
 
-
 std::vector<std::string> Utils::backtrace()
 {
     std::vector<std::string> lines;
 #ifndef WIN32
+#ifdef HEXER_HAVE_EXECINFO_H
     const int MAX_STACK_SIZE(100);
     void* buffer[MAX_STACK_SIZE];
     std::vector<std::string> prefixes;
@@ -657,9 +659,9 @@ std::vector<std::string> Utils::backtrace()
         }
     }
 #endif
+#endif
     return lines;
 }
-
 
 // Useful for debug on occasion.
 std::string Utils::hexDump(const char *buf, size_t count)

--- a/hexer_defines.h.in
+++ b/hexer_defines.h.in
@@ -25,6 +25,11 @@
 #cmakedefine HEXER_HAVE_GDAL
 
 /*
+ * availability of execinfo and backtrace
+ */
+#cmakedefine HEXER_HAVE_EXECINFO_H
+
+/*
  * Debug or Release build?
  */
 #define HEXER_BUILD_TYPE "@CMAKE_BUILD_TYPE@"


### PR DESCRIPTION
Run a more generic compile test to see if execinfo.h is available, and include
it conditionally.