### PR TITLE
Remove version constraint on GDAL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFSPEC GIT_SHA1)
 
-find_package(GDAL 1.9.0 REQUIRED)
+find_package(GDAL REQUIRED)
 
 
 ###############################################################################


### PR DESCRIPTION
This caused issues for me when trying to build hexer with a vcpkg-provided copy of GDAL. 1.9.0 is hilariously old so it should be fine to drop the version check entirely.